### PR TITLE
Bug fixed (SocksPort) and add the DataDirectory command

### DIFF
--- a/src/Tor/ClientCreateParams.cs
+++ b/src/Tor/ClientCreateParams.cs
@@ -192,9 +192,6 @@ namespace Tor
             builder.Append("--allow-missing-torrc ");
             builder.AppendFormat("--ControlPort {0}", controlPort);
 
-            /** TEMPORARY: DELETE LATER **/
-            builder.AppendFormat(" --SocksPort 9050");
-
             if (!string.IsNullOrWhiteSpace(configurationFile))
                 builder.AppendFormat(" -f \"{0}\"", configurationFile);
 

--- a/src/Tor/Configuration/Configuration.cs
+++ b/src/Tor/Configuration/Configuration.cs
@@ -140,6 +140,15 @@ namespace Tor.Config
         }
 
         /// <summary>
+        /// Gets or sets the data directory path.
+        /// </summary>
+        public string DataDirectory
+        {
+            get { return GetValue(ConfigurationNames.DataDirectory) as string; }
+            set { SetValue(ConfigurationNames.DataDirectory, value); }
+        }
+
+        /// <summary>
         /// Gets or sets a value indicating whether the Tor application shouldn't listen for accept any connections other than control connections.
         /// </summary>
         public bool DisableNetwork

--- a/src/Tor/Configuration/Enumerators/ConfigurationNames.cs
+++ b/src/Tor/Configuration/Enumerators/ConfigurationNames.cs
@@ -43,6 +43,9 @@ namespace Tor.Config
         [ConfigurationAssoc("ConstrainedSockSize", Default = 8388608.0, Type = typeof(Bytes), Validation = ConfigurationValidation.NonNull | ConfigurationValidation.SizeDivision)]
         ConstrainedSockSize,
 
+        [ConfigurationAssoc("DataDirectory", Default = null, Type = typeof(string))]
+        DataDirectory,
+
         [ConfigurationAssoc("DisableNetwork", Default = false, Type = typeof(bool))]
         DisableNetwork,
 


### PR DESCRIPTION
Fixed a bug in ClientCreateParam.cs (SocksPort hardcodded which prevented the user to specify its socks port)

Add the DataDirectory command option (ConfigurationNames.cs & Configuration.cs)